### PR TITLE
Upgrading High Severity Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -937,32 +937,53 @@
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.7.tgz",
-      "integrity": "sha512-Rs3ETtMtR3VLXFeYRChle5SsP/P9Jp/6dsewBQfokDSzKJThlsuFcnzLTDRALiUmTC48ej19YD9uN1mupEeEDg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.11.tgz",
+      "integrity": "sha512-5MvsGschXeXJsbzQGR/BH89ATMzCsM7rx95n+R7/852cGoK2JgMbacDw/A9Pmrfex4tArdMab0L5SBV4SB/Nxg==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.4",
+        "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-jsx": "^7.12.1"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.12.1.tgz",
-      "integrity": "sha512-FbpL0ieNWiiBB5tCldX17EtXgmzeEZjFrix72rQYeq9X6nUK38HCaxexzVQrZWXanxKJPKVVIU37gFjEQYkPkA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.12.1.tgz",
-      "integrity": "sha512-keQ5kBfjJNRc6zZN1/nVHCd6LLIHq4aUKcVnvE/2l+ZZROSbqoiGFRtT5t3Is89XJxBQaP7NLZX2jgGHdZvvFQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.12.10",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+          "integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.10"
+          }
+        },
+        "@babel/helper-builder-react-jsx-experimental": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.11.tgz",
+          "integrity": "sha512-4oGVOekPI8dh9JphkPXC68iIuP6qp/RPbaPmorRmEFbRAHZjSqxPjqHudn18GVDPgCuFM/KdFXc63C17Ygfa9w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.12.10",
+            "@babel/helper-module-imports": "^7.12.5",
+            "@babel/types": "^7.12.11"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+          "integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -1157,18 +1178,67 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.7.tgz",
-      "integrity": "sha512-wKeTdnGUP5AEYCYQIMeXMMwU7j+2opxrG0WzuZfxuuW9nhKvvALBjl67653CWamZJVefuJGI219G591RSldrqQ==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.10.tgz",
+      "integrity": "sha512-vtQNjaHRl4DUpp+t+g4wvTHsLQuye+n0H/wsXIZRn69oz/fvNC7gQ4IK73zGJBaxvHoxElDvnYCthMcT7uzFoQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-transform-react-display-name": "^7.12.1",
-        "@babel/plugin-transform-react-jsx": "^7.12.7",
+        "@babel/plugin-transform-react-jsx": "^7.12.10",
         "@babel/plugin-transform-react-jsx-development": "^7.12.7",
-        "@babel/plugin-transform-react-jsx-self": "^7.12.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.12.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.12.10",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+          "integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.10"
+          }
+        },
+        "@babel/helper-builder-react-jsx-experimental": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.11.tgz",
+          "integrity": "sha512-4oGVOekPI8dh9JphkPXC68iIuP6qp/RPbaPmorRmEFbRAHZjSqxPjqHudn18GVDPgCuFM/KdFXc63C17Ygfa9w==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.12.10",
+            "@babel/helper-module-imports": "^7.12.5",
+            "@babel/types": "^7.12.11"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/plugin-transform-react-jsx": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.11.tgz",
+          "integrity": "sha512-5nWOw6mTylaFU72BdZfa0dP1HsGdY3IMExpxn8LBE8dNmkQjB+W+sR+JwIdtbzkPvVuFviT3zyNbSUkuVTVxbw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-builder-react-jsx": "^7.10.4",
+            "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-jsx": "^7.12.1"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+          "integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/runtime": {
@@ -1262,21 +1332,21 @@
       }
     },
     "@parcel/babel-ast-utils": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/babel-ast-utils/-/babel-ast-utils-2.0.0-beta.1.tgz",
-      "integrity": "sha512-0Jod0KZ2gCghymjP7ThI/2DfZQt9S2yq1wTvBwyJ46Ij3lIZVmXBVWs4x8O0uvKMUjS5zrnSFgurimFORLmDbQ==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/babel-ast-utils/-/babel-ast-utils-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-oIrhvCdkJpyX+SzOxR/nd9e4DwogspAsf7rXgzKqDbiYZ4WrMbSFoL4HeMScWXX2UHg3OdtMfbYSqp7sdpuCXw==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.0.0",
         "@babel/parser": "^7.0.0",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/babel-preset-env": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.0.0-beta.1.tgz",
-      "integrity": "sha512-/TK/xE9Rfy6weu0eWifnGCntCt4i7DoFCKgigdSsHbuRA4w7BfnwS0GIOAQ6gORRXIf4lM8cGsnp5jRP2PhwLw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-JezrkS7HTFvNc08sDc5ZwQvBQ+RNYlvFnXjwfDjMBwnJOT20F2oVxoEyOsIftBY5nf5cZtpBQ11UtaSiUWdD9w==",
       "dev": true,
       "requires": {
         "@babel/preset-env": "^7.4.0",
@@ -1284,9 +1354,9 @@
       }
     },
     "@parcel/babylon-walk": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/babylon-walk/-/babylon-walk-2.0.0-beta.1.tgz",
-      "integrity": "sha512-FWZErHc2Q62lrWxfMoRl1mej8HCr3tXvzeVgMfv2cbiOjaZIrN+8khD0AcRyesnm5JipgT8KQoJvl8ZdU9DFAw==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/babylon-walk/-/babylon-walk-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-c/Fmle3HLuzs+5aAWmlghHkEMWsi0VYhfe0/cQ2BkSCEL7g48dEwaVKr7zjF0TSlKkvJt+Q5Ci2Ps9SFu9V0YA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
@@ -1294,30 +1364,31 @@
       }
     },
     "@parcel/bundler-default": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.0.0-beta.1.tgz",
-      "integrity": "sha512-ksRBQcZ4OQwZ+pWl28V/G5z6JR/fZUSdXSJwyVJKCUQhKLp0qVZ0emYnZFLg+24ITemRosPH9tNMyQwzNWugsw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-igktFdvFcyWuIK/gFfMx60Cmt+PAmg67y1Ryu3N7FPBuSMJPEw8rjd5Mi51pP6dv3jKkvELt3ir+AcrYcamR/w==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-beta.1.tgz",
-      "integrity": "sha512-o8GMPcrVH31uctXQGGX6O28T7Bm4dqM0DbJRCDtxixGQosKyN9OlAA84390XOti2Fjr1Av/U1ALmbdavQsdcYA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-QSltWk+IT1AXZW72NYyLaKsMwAfmEP/iqXL+fxjepnFZ5NRGP3sat6fAMnOA1NlHQntQBzFxLPZa2j2p3o+KsQ==",
       "dev": true,
       "requires": {
-        "@parcel/logger": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/logger": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-beta.1.tgz",
-      "integrity": "sha512-HyFjYSPysYumT/T3JdZN8y0DXhXLMpmlg94rADR+Wf5Wp1YMTuIHlE1gkfbjIj1m2PxJWe4UMbniGwy3KQh9zQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-WvVJq97uPa5dQc6wgCAQTfVIjLZahM6sNdCyaM55vcdj6OL6nYlgPCHq6fhSkK66+SR1dup2rKKZCs0erWeQJw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -1379,74 +1450,79 @@
       }
     },
     "@parcel/config-default": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.0.0-beta.1.tgz",
-      "integrity": "sha512-VEJYkiF+RNaB28OPmk1sCsOapWPisu5MXV+8N7T5ERa7xOOaD2SbD5/JnOjuUGAYKALk8UBsTCG+3ukMQ7Fiuw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-uZSqWgLFPKMDpmiIbxY3inkEtiR0uA4TscHHlua2F0lwxntspEPmGOnt0fASi8V8sBoumc1rVbllwddwmNVaPw==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.0.0-beta.1",
-        "@parcel/namer-default": "2.0.0-beta.1",
-        "@parcel/optimizer-cssnano": "2.0.0-beta.1",
-        "@parcel/optimizer-data-url": "2.0.0-beta.1",
-        "@parcel/optimizer-htmlnano": "2.0.0-beta.1",
-        "@parcel/optimizer-terser": "2.0.0-beta.1",
-        "@parcel/packager-css": "2.0.0-beta.1",
-        "@parcel/packager-html": "2.0.0-beta.1",
-        "@parcel/packager-js": "2.0.0-beta.1",
-        "@parcel/packager-raw": "2.0.0-beta.1",
-        "@parcel/packager-raw-url": "2.0.0-beta.1",
-        "@parcel/packager-ts": "2.0.0-beta.1",
-        "@parcel/reporter-bundle-analyzer": "2.0.0-beta.1",
-        "@parcel/reporter-bundle-buddy": "2.0.0-beta.1",
-        "@parcel/reporter-cli": "2.0.0-beta.1",
-        "@parcel/reporter-dev-server": "2.0.0-beta.1",
-        "@parcel/resolver-default": "2.0.0-beta.1",
-        "@parcel/runtime-browser-hmr": "2.0.0-beta.1",
-        "@parcel/runtime-js": "2.0.0-beta.1",
-        "@parcel/runtime-react-refresh": "2.0.0-beta.1",
-        "@parcel/transformer-babel": "2.0.0-beta.1",
-        "@parcel/transformer-coffeescript": "2.0.0-beta.1",
-        "@parcel/transformer-css": "2.0.0-beta.1",
-        "@parcel/transformer-graphql": "2.0.0-beta.1",
-        "@parcel/transformer-html": "2.0.0-beta.1",
-        "@parcel/transformer-inline-string": "2.0.0-beta.1",
-        "@parcel/transformer-js": "2.0.0-beta.1",
-        "@parcel/transformer-json": "2.0.0-beta.1",
-        "@parcel/transformer-jsonld": "2.0.0-beta.1",
-        "@parcel/transformer-less": "2.0.0-beta.1",
-        "@parcel/transformer-mdx": "2.0.0-beta.1",
-        "@parcel/transformer-postcss": "2.0.0-beta.1",
-        "@parcel/transformer-posthtml": "2.0.0-beta.1",
-        "@parcel/transformer-pug": "2.0.0-beta.1",
-        "@parcel/transformer-raw": "2.0.0-beta.1",
-        "@parcel/transformer-react-refresh-babel": "2.0.0-beta.1",
-        "@parcel/transformer-react-refresh-wrap": "2.0.0-beta.1",
-        "@parcel/transformer-sass": "2.0.0-beta.1",
-        "@parcel/transformer-stylus": "2.0.0-beta.1",
-        "@parcel/transformer-sugarss": "2.0.0-beta.1",
-        "@parcel/transformer-toml": "2.0.0-beta.1",
-        "@parcel/transformer-typescript-types": "2.0.0-beta.1",
-        "@parcel/transformer-yaml": "2.0.0-beta.1"
+        "@parcel/bundler-default": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/namer-default": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/optimizer-cssnano": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/optimizer-data-url": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/optimizer-htmlnano": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/optimizer-terser": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/packager-css": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/packager-html": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/packager-js": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/packager-raw": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/packager-raw-url": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/packager-ts": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/reporter-bundle-analyzer": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/reporter-bundle-buddy": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/reporter-cli": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/reporter-dev-server": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/resolver-default": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/runtime-browser-hmr": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/runtime-js": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/runtime-react-refresh": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-babel": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-coffeescript": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-css": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-elm": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/transformer-glsl": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/transformer-graphql": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-html": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-image": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/transformer-inline-string": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-js": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-json": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-jsonld": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/transformer-less": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-mdx": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/transformer-postcss": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-posthtml": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-pug": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-raw": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-react-refresh-babel": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-react-refresh-wrap": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-sass": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-stylus": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-sugarss": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-toml": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-typescript-types": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/transformer-vue": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/transformer-yaml": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/core": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.0.0-beta.1.tgz",
-      "integrity": "sha512-1KKjhL2H7z8qJNgY2M3CreYqbKopJT6ImlJk54ynIrLuJsnqKuA80FHYBiAtnSZEA65mvAJ3YLReFhg9slzbFw==",
+      "version": "2.0.0-nightly.481",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.0.0-nightly.481.tgz",
+      "integrity": "sha512-Qo2kVa4A5qStCC2nuDPeC/c/K8RvuQfrdj72y69nj96bR0jiMNuEH2li069FmWWXLGzmDRs0ep4z2uc5sv+jDQ==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.0.0-beta.1",
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/events": "2.0.0-beta.1",
-        "@parcel/fs": "2.0.0-beta.1",
-        "@parcel/logger": "2.0.0-beta.1",
-        "@parcel/package-manager": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/types": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
-        "@parcel/workers": "2.0.0-beta.1",
+        "@parcel/cache": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/events": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/fs": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/logger": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/package-manager": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/types": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/workers": "2.0.0-nightly.483+a4cf3e95",
         "abortcontroller-polyfill": "^1.1.9",
+        "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
         "dotenv": "^7.0.0",
@@ -1455,13 +1531,14 @@
         "json5": "^1.0.1",
         "micromatch": "^4.0.2",
         "nullthrows": "^1.1.1",
+        "querystring": "^0.2.0",
         "semver": "^5.4.1"
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-beta.1.tgz",
-      "integrity": "sha512-LNfe2MgbKiqXnEws1QT9tANeg6iw+u6hNnuO2ZjRdnAIF/LqslD/6RKryE1yD1lh71ezACwLscji0CLuys6mbg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-XOMdt4hLnYih3GghxhO9SVy7buLdzK+PUgNxfqNVThH6UqsKuZBvnwNu7/M7SUdMhda3oXopVtxK80N7ekCQTw==",
       "dev": true,
       "requires": {
         "json-source-map": "^0.6.1",
@@ -1469,31 +1546,43 @@
       }
     },
     "@parcel/events": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-beta.1.tgz",
-      "integrity": "sha512-m//K2aHYnr4tSONlUmS0HhNQtmhYjCUJ+dv85mfLEqLlQVmsLBwxlcqBS5M1ONlaGPlI87xUKY8uBTg8kY1q4g==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-a+Yx9Tk8IGb087vZpgdMl3VwULRI+qu3DquLeLEUOeN73SdVl6ADiOsPar/ip/GgKy4duuLbFBrRZ+GpOmKLHQ==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-beta.1.tgz",
-      "integrity": "sha512-THLgnN+eaxfa4s0T3KIuOB1N4Lg5lwlz2Y1Y69vWujZh3B3PHbNDlJ4n0O0m+vgYZoJZ43X+qxId0yeHUh6p0w==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-OZntJxK+5yopxR+10VoIM+iADanEod7QgFXLwm5BPXPLLHqfCAPndtPJ0aTClBJjZYRfwbCEWLlkqGDYXS5UyQ==",
       "dev": true,
       "requires": {
-        "@parcel/fs-write-stream-atomic": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
-        "@parcel/watcher": "^2.0.0-alpha.5",
-        "@parcel/workers": "2.0.0-beta.1",
+        "@parcel/fs-write-stream-atomic": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/watcher": "2.0.0-alpha.8",
+        "@parcel/workers": "2.0.0-nightly.483+a4cf3e95",
+        "graceful-fs": "^4.2.4",
         "mkdirp": "^0.5.1",
         "ncp": "^2.0.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^2.6.2"
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@parcel/fs-write-stream-atomic": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-write-stream-atomic/-/fs-write-stream-atomic-2.0.0-beta.1.tgz",
-      "integrity": "sha512-ZL3da/3jhMvu6ZwZBmxEiGXOLq+qvVvvx6DVv+4JQV0EMAFp7gvD4CH0QKLCgKBbjd1wqEBPyW3CCEo5tGtAHA==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-write-stream-atomic/-/fs-write-stream-atomic-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-T/RTQLZ7hXHzkeSRxLC5I3uCqDI3LMzTbB8tOVpmx3CSKsB7GcqogSirinNRa03BeRJg2b+zRePxUbL2bSzLTA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1535,19 +1624,19 @@
       }
     },
     "@parcel/logger": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-beta.1.tgz",
-      "integrity": "sha512-PMhAs1vCPSDKt977w0cMNCEHjBTy94Khc1Pr07/YXwiijxzDBxPS9JmV8dBbryTheRy/EyUhJDXES3brQwiiqw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-2aLDzWnuyPf/dVdixMx+ZCSGdUgdXWSlkUYCs2JhwPvYlbqp7TTR/vhze5ZRZoyJsxNozIEh6R2NZdKHF1bMZQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/events": "2.0.0-beta.1"
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/events": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-beta.1.tgz",
-      "integrity": "sha512-J1r4m7LczK+X26p/tjA+9VP0g4vzYNUlUyFvIHt7dcdSVEjLM2ICUQZSIzlRHXlVQ+ciMxOFUYtDBCzAzXiLfQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-MrBab5MZkt6ehtQyEcjTA2gCiBAWsU9//p1l6/qvMO1rHjUcKae3mAaNDsESA7+WH1uD5ft4u+yP+8+n0eXgPg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2"
@@ -1606,20 +1695,20 @@
       }
     },
     "@parcel/namer-default": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.0.0-beta.1.tgz",
-      "integrity": "sha512-b3In/s++ykB/EL2CLAFWEx0/GUaQ0TMXAfpLfd9wCmqsJq1MQxW437aujF5bIDNHjEE7+rnGk4XP+IO9uViWpQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-ofreaYoE0Ji1N9NuORQ29aUrABX+UqQBjosJvtCl+iAmtl9csa2IgeREPx6Dj13tg9s1rpmVWpVlEMdGUP9BBA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-libs-browser": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/node-libs-browser/-/node-libs-browser-2.0.0-beta.1.tgz",
-      "integrity": "sha512-U9pS9KwhTluA9atSzU4X5173BXRER7BRqPSSAEBrfAbCeIfzAG1d1+bhyMZs3SBSt6afWU5HBy//wB8OWBqcKw==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/node-libs-browser/-/node-libs-browser-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-dw+7spJ+JVtxj9vzeFYi2nPAqnGj504RPupwFkxlvNcZonLpVcSGracHMhFIS0r/1ttnGCBeUGB4NS9BAw3/3Q==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -1655,16 +1744,17 @@
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.0.0-beta.1.tgz",
-      "integrity": "sha512-A2Eu+TEnh90Q+iisNfKmaHTPbIR/eshRUqze8PFvSTKv+n9ejNOJ0GCb+x/PFqeqavJRXUBFc60F2pAp88+Bjw==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-YlZ0fthkaZRSu+gV/GF1/nzMrF5oRnYOQAhboA6ZEgw/jUTty/Lxis/MUM2KV1ETtaZ9hGRnf6y28HNyR9uzOg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/node-libs-browser": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/node-libs-browser": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "micromatch": "^3.0.4",
-        "nullthrows": "^1.1.1"
+        "nullthrows": "^1.1.1",
+        "querystring": "^0.2.0"
       },
       "dependencies": {
         "braces": {
@@ -1773,54 +1863,67 @@
       }
     },
     "@parcel/optimizer-cssnano": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-beta.1.tgz",
-      "integrity": "sha512-f7Yz7kWAVvhRmT/QXNFrlR//pE7D1+G4iWYKstUFWJP0SsoquQBUsb3NI6vltUvydN6htcCRHGX9GhAnHRpaFw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-v5/QKAk3btd7OpaFyEK+tWPqNoqqVOUAUr6dSsTNb2wYN/KTjQ4G5DCjObTQj7InP+/p1RQpqn8ewL6KboLu8A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
         "cssnano": "^4.1.10",
-        "postcss": "^7.0.5"
+        "postcss": "^8.0.5"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.1.tgz",
+          "integrity": "sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==",
+          "dev": true,
+          "requires": {
+            "colorette": "^1.2.1",
+            "nanoid": "^3.1.20",
+            "source-map": "^0.6.1"
+          }
+        }
       }
     },
     "@parcel/optimizer-data-url": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-data-url/-/optimizer-data-url-2.0.0-beta.1.tgz",
-      "integrity": "sha512-H+oMRbBsYXm0GEpzwkaNO3VMxmt50yIg9IE3dyAkXDIZ4kOpaDxYJkGuuR51L5BzQSbEeXwipzoqd2LoLJ8O6w==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-data-url/-/optimizer-data-url-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-mPYqgo1QRvYjL2jpMA5G5fAxUcelyaZXk3P8Kmg2xAIgAzlM4pQmh75D162uiZjpJox845XnLyq3GDOxL611/A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "isbinaryfile": "^4.0.2",
         "mime": "^2.4.4"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-beta.1.tgz",
-      "integrity": "sha512-Mz8gkvOd6pyazQFmOjGugz6Q8ydxqjeA6PyrE21/cTj8CtmLCs4TCfEzLcU79qHyr8a+KVx4roTCUwTGv+J/7Q==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-Y2/4dnj8xcWhELmW/6MkEa9RWe838CAu6jSHTdyGUKZWypPg58e0bIfHAIwnKnPVF6/sg3ku06hNTvbBWXHsLg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "htmlnano": "^0.2.2",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-beta.1.tgz",
-      "integrity": "sha512-S6uu4Q4L8NV+TQes35dQmHqcA6NaRmQSI0vl75IGSaTJnvnq/M3fvrTUd6Xp4dOt/eLh4UJEH7F01TbO1KFZwg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-2UMApPao7IaI0klB1Z1QpsGcyAz5kYV8KztbCJf8jJZ6QirSAymaDjq2WmIOGYtJ/sYm/pwVvN7zkQD8lkwO3g==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1",
-        "terser": "^4.3.0"
+        "terser": "^5.2.0"
       },
       "dependencies": {
         "commander": {
@@ -1829,30 +1932,36 @@
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
         "terser": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
+          "integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.19"
           }
         }
       }
     },
     "@parcel/package-manager": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-beta.1.tgz",
-      "integrity": "sha512-3i7YXkR0TjJ7RcDpLV5ki5PLsBcdux9BILctC3LLQbNrW5kZjwztEOCnaHJbcQ3VaHaLu6znU8y24EPoyBOPMA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-DJMdpnwMB6dtvvyHHo04wqKCaTA2WCbd4HSZj7ZHcrHUBK7dzeDpe7dzehPJ9lv3hw9A9IuxOCWFXXl8Et70ig==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/fs": "2.0.0-beta.1",
-        "@parcel/logger": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
-        "@parcel/workers": "2.0.0-beta.1",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/fs": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/logger": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/workers": "2.0.0-nightly.483+a4cf3e95",
         "command-exists": "^1.2.6",
         "cross-spawn": "^6.0.4",
         "nullthrows": "^1.1.1",
@@ -1862,109 +1971,109 @@
       }
     },
     "@parcel/packager-css": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.0.0-beta.1.tgz",
-      "integrity": "sha512-oi69yNnSZTuQ8y8GuHOFgZ9qQ5oBktNuOEhOoHd7Y15Srior/SwPjx0/UypBweEiKRGApipJtrgo0XQvr5x9aQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-qIsIV8LSFSqaBMJQgq/0CJVL6i0b1Sr8mJALdtCNU0VBjkwhFEFiyOsvJo/w3s1/1XBfrh+rZl7TKQAUJSkr0A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.0.0-beta.1.tgz",
-      "integrity": "sha512-ixuLWNpFGNYCKHbrhx2mY/aal1ORJyjaOozCLx2jL5888JeCw34jCWZcXSej+hc50KICr/RVd/WrA5v6YvkBMA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-cdq2fK+estQNKGgfwd8yjDrWMbbKjg3pKLoKTREWf2M+LlE1Mvg2EFcJ01Qta6EoYVMpnNLZQKjPSGiqH7lQ1A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/types": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/types": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.0.0-beta.1.tgz",
-      "integrity": "sha512-4sWVYv/uPDokftaMquZa1f70wE5O85bcRklcs0kUGPjWNf3uaCG/tS6h9USD2GDbcdjY1xDNoClu6EUTM1AvhA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-rg5ntenzaDfTVqH073vAUpG3cdsp5jWhs7YLqvXT+0FufEgNNkKwXUXEo/fooZ6E6p/qS4t5EV2u2DZGGPkFHQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.2.3",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/scope-hoisting": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/scope-hoisting": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.0.0-beta.1.tgz",
-      "integrity": "sha512-Os8m1DuPfGqjcR4avbZbJ79Rz2bvGsHx49BJ8HtJj0YnpZbnox7z5njn4PlpWhr2XAJmNnctrQ8ES0Qvrop/AQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-guj8nW/7FaQjhQfOSLheD+zoI+PhTh4KX+OVl8vVPTmEE72BCD16nLxtjhAqC2EeVJxjDNrWMW5fM9/lCag1jA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/packager-raw-url": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw-url/-/packager-raw-url-2.0.0-beta.1.tgz",
-      "integrity": "sha512-elXRSp0ig1Q4y2xMpp3AGPVPFHOB0dW/qT3FbXJwBQhUtjOJrfOtQUlT59l0xP57pADS2aihgnQx0Vl13lL7FQ==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw-url/-/packager-raw-url-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-CTH1u4cfDKUYefv5hmGoHqEiXXCTnj3IFEonFNuqxiAQukU+2UGF/uqgLea47Tdh6xTVzN/83YGW2e4ETfUgvQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/packager-ts": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.0.0-beta.1.tgz",
-      "integrity": "sha512-x/sOSvIVV6z7ltG1XFuJ/Da72HAHkRxNLCzE2ggEnuB9kzOWXAlIHKeeGB2Ql3lV2OOMtoQoFg4BM1nBLJzFCg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-2Me67HSUvDFI2fwKTcTzb48Goo75WWV84bGTRsxz/5oSaT0xf0aVryOvSN0wVM3Sb3r+44U+w3YpcTM5BPc6Sw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/plugin": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-beta.1.tgz",
-      "integrity": "sha512-ik8kwNTJ7wfPRWHQK5NrUat3WGOZazIv8v1Lbgew6XuVTc333FitvBn6mxpPWp2N3+GWWrVGmBG8m7MI6kB8zw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-xwmiDwxAVOwh+ukBxu6hLLWKWPB5A9dlQ1GIQD+MsVEzEHt71yz+x02iCTTOWhtC3Dkp2w78CKLH0L3OVTLwUA==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.0.0-beta.1"
+        "@parcel/types": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/reporter-bundle-analyzer": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-beta.1.tgz",
-      "integrity": "sha512-igUEsMSgyIiAEvmjdIydcmYpTFUKQB5EAtbMEYvRWlCSEGR08EZqaY58SIiTaTUv4maQuAi0k7E3QQSDeBtQ/w==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-analyzer/-/reporter-bundle-analyzer-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-8NAZ4+1tJIJo5vcA+EiKFx/KyZKQs8ummRviAaIaoiNlt7J9G8BM5WYSxdrsOJXMXBAulLtnBRvCYLikWLw+Rg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/reporter-bundle-buddy": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-buddy/-/reporter-bundle-buddy-2.0.0-beta.1.tgz",
-      "integrity": "sha512-pW7SJFKGkkjOOYYcE20BgleC1DRswM04fZ82S9NS0idnEsJ1Z+z/QCww24J1Vfx5FGEQDVOl4siHNILm04kvdg==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-bundle-buddy/-/reporter-bundle-buddy-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-mqz9VzkIztYil2H7Gv7cXC6DagfmSEEdjbeR/vNpR5W6SJDNYLOYafM4YGJ7zb8NHD/RElsvmZkF8Zw0obv38Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.0.0-beta.1.tgz",
-      "integrity": "sha512-KmyfFhClXghMxZXbS8tkoXZZqVfuLzlUDwedMAN+Jr9h8vSZYaiqjq88mNdrLIubqLepbNG7jUcXPu/Y3ynz6Q==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-niZnEL8+Yigh5HP3CNJOt4IX3PFONg+cQk6a0Jaj9vqsBx6ioUq7EjNqCxj2WoFnh3phc5AdOvU2Y5WeQqWKxw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/types": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/types": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "chalk": "^3.0.0",
         "filesize": "^3.6.0",
         "nullthrows": "^1.1.1",
@@ -1987,97 +2096,106 @@
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-beta.1.tgz",
-      "integrity": "sha512-84u4lfwAqGrIrbuyTYq88PckSe1mKP+f+D5aQDObWBqDy1gSokM+yKnQQHoddQAhviyTY3tJU/SEvKSp0Dog9Q==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-5kMSro/H2NCE87OGvvheo/ekhSl67uN99rv+MYHUsIvSvY/n02eq9yhNctOmbEL9eAYADtdTIPuhRRQ8+zNYWA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "connect": "^3.7.0",
         "ejs": "^2.6.1",
-        "http-proxy-middleware": "^0.19.1",
-        "mime": "^2.4.4",
+        "http-proxy-middleware": "^1.0.0",
         "nullthrows": "^1.1.1",
-        "ws": "^6.2.0"
+        "serve-handler": "^6.0.0",
+        "ws": "^7.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+          "dev": true
+        }
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.0.0-beta.1.tgz",
-      "integrity": "sha512-BnnHY83oqOIk3oK7QsJbB2QdtSIWVy948JI7bhfFC0+8zWMLifE28KTZQD1JGxICOre75DK1JRN26l8F1gtuiw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-SL12AUikrrF1F/90YEtBIYws9shh9d+kZMMcOwWf4OxMS5sg/CJUde4lCv8/VTqEH1HmIf9eddTb25t52JeVuQ==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/node-resolver-core": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-beta.1.tgz",
-      "integrity": "sha512-5JQGDLwqAGk0kNqlgKPA99mPN8srpabu/2drpxSBKWXDA71v47JRYcGx8gQsvdZGgj3+rrkI2nyC8UlYAM+m+w==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-squ+kvO8FJHp+bOCwgj60Nh68yg/pQiY4CKS6nQuNlnC31qJ+MNz9UDHTeaIiGdN1QWJVrLSKcfOx0B7yKhNmg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.0.0-beta.1.tgz",
-      "integrity": "sha512-1EHrOoNzCdksj4QfLuIr5rC8rO8FsVpQdl4ZLggMsxQV67wFiG9j1KwM/+Jmpd6dsmdkSW+b/NAC5kPXnE1EfQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-Po2Kepi4sNSlI8BKaW3CwVEV49b4KNxZUSwxX00znRY7h1fF3L/fKHokby4JL0DKduzxK7uK/7OgyTNmnjFt+Q==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-beta.1.tgz",
-      "integrity": "sha512-d7lShNcgyKAdrDwAqNzVeOeQ7MuqtElw4YPxHAmTrJnsr8k+scPmK7IiUSPqItuvLIngpS1IoLY1SuEAQAY/QA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-xlZ/3Zc5ms1EJMbX7I4B2KSy2KiLEuAhDCZPQAqkEdT3UejYYElC+EBz3jVk4OxhtE06aCsGsxLr+4FCC8CdQw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "react-refresh": "^0.6.0"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "react-refresh": "^0.9.0"
       }
     },
     "@parcel/scope-hoisting": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/scope-hoisting/-/scope-hoisting-2.0.0-beta.1.tgz",
-      "integrity": "sha512-U0ZcejwG6vMj+cLHScQ7lhPWaaXgNk+xGPu6adWNQVbRB3PqJMv6jIhBwgR2afWzNwu1a3vg1aRO9DH/jpxGdg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/scope-hoisting/-/scope-hoisting-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-8zV0wAEzTXtVyp5zWIDiF0aFdXyeXJEctOSjQ1YzFSSI3CqY5reUnod/KHBjsYED38l3qB97t0n/7SpAHaT3vg==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.3.3",
         "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.2.2",
+        "@babel/template": "^7.4.0",
         "@babel/traverse": "^7.2.3",
         "@babel/types": "^7.3.3",
-        "@parcel/babylon-walk": "2.0.0-beta.1",
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/babylon-walk": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/source-map": {
-      "version": "2.0.0-alpha.4.13",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.0-alpha.4.13.tgz",
-      "integrity": "sha512-MnIfYmaRqnwK8kRRG9Osu1DkJGl2bVSfJs9SqauJ9N4dOdAXAFGeeDtzXnHvx02DO+HwK7YjsbhBpSvvgZcWHg==",
+      "version": "2.0.0-alpha.4.19",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.0-alpha.4.19.tgz",
+      "integrity": "sha512-pb8ciLbctRE/Z2KTJnVPvlrHm/ArG3IdX5nPDz3qcEA0RHDFikfv3/WZHO77b5/jtDHhvHuaBqmqPpVr0OuVRg==",
       "dev": true,
       "requires": {
-        "node-addon-api": "^2.0.0",
+        "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.2"
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.0.0-beta.1.tgz",
-      "integrity": "sha512-nP8TsjhYYvL5NjRX6WNZFXjcY66fwrPthslnycNldoHpmRDoRO1PFjqx1zzJJEUc1S0r6M2kTQhDuh4dXhANCA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-nwC1n4NgkUjqfbAWI6BE1dD4hLDF+QrRCZnMT6BG5DREH413wvgSi+6o8pOLkxnBgnCuiEW0mb8L4gUKh4FXTg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0",
+        "@babel/core": "^7.12.0",
         "@babel/generator": "^7.0.0",
         "@babel/helper-compilation-targets": "^7.8.4",
         "@babel/plugin-transform-flow-strip-types": "^7.0.0",
@@ -2085,10 +2203,10 @@
         "@babel/preset-env": "^7.0.0",
         "@babel/preset-react": "^7.0.0",
         "@babel/traverse": "^7.0.0",
-        "@parcel/babel-ast-utils": "2.0.0-beta.1",
-        "@parcel/babel-preset-env": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/babel-preset-env": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "browserslist": "^4.6.6",
         "core-js": "^3.2.1",
         "nullthrows": "^1.1.1",
@@ -2096,58 +2214,153 @@
       }
     },
     "@parcel/transformer-coffeescript": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.0.0-beta.1.tgz",
-      "integrity": "sha512-EP0+RAGrMIGoIG3g3VdjAIkMCfFj8gnVp8e8n61nzrnqE7pmF8KuGtGAYz6U8yQb39a1OF41sEg1huvOUT3nKw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-zllODuGOEqo1gA0/99Axgl/i1Dl5oILJuOAHFbNjHkPJo+bcU03SwmotJq8f9mRICUioKIU6y9qA2AAmgsNHhQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "coffeescript": "^2.0.3",
         "nullthrows": "^1.1.1",
         "semver": "^5.4.1"
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.0.0-beta.1.tgz",
-      "integrity": "sha512-+vRvTWeQNxzRfsv9A9gGXYt6p6NU6LcyLvByIMzwDhqsMq1wsIEmw+YPM/2TzqsKI/f+B0jkTNCMI2dQobFX0g==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-Pe09yGijE5C+Y9j8fhA7adGPBIl4ZRDvbc8PHUCCt17Ymg67IoGJETbGwFrEQgyD7GJp18WzyVZtdnXXYfpOTg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1",
-        "postcss": "^7.0.5",
-        "postcss-value-parser": "^3.3.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "postcss": "^8.0.5",
+        "postcss-value-parser": "^4.1.0",
         "semver": "^5.4.1"
       },
       "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
+        "postcss": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.1.tgz",
+          "integrity": "sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==",
+          "dev": true,
+          "requires": {
+            "colorette": "^1.2.1",
+            "nanoid": "^3.1.20",
+            "source-map": "^0.6.1"
+          }
         }
       }
     },
-    "@parcel/transformer-graphql": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-graphql/-/transformer-graphql-2.0.0-beta.1.tgz",
-      "integrity": "sha512-IYuSUHadoEn5plZx78fZr8ViGdU2GqbY0opkGP21i1Z0TiB4h0ON9VMbEgnABAGeR1b+9rly/8e9/isOC7jcow==",
+    "@parcel/transformer-elm": {
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-elm/-/transformer-elm-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-0brCnu+cbzQoXnd6VPvvqRFiG5JGmd3WFeSqnxH3Hb9Hd/cVbh+gGf61SuA5Ks94zR/KpXxqamQRZlSn1aCWAg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "command-exists": "^1.2.8",
+        "cross-spawn": "^7.0.3",
+        "nullthrows": "^1.1.1",
+        "terser": "^5.2.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "terser": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
+          "integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.19"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@parcel/transformer-glsl": {
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-glsl/-/transformer-glsl-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-ag5LFWiu/osjy3Fe0ikLAsXzovHMNMEpXowYITmKeVrg++FsYa/9hKNZxuL+m+ZG0r9a8Mj0BwJ96dcI2VIjqw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
+      }
+    },
+    "@parcel/transformer-graphql": {
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-graphql/-/transformer-graphql-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-TkXhmwUzfIGgSTvcvrBgXWiBSjrPkzxdRCrWmixHA5rTwuXGvg2UQkrNJmbxN0PDFvndJ2X0n9MxHR1D6eLU8A==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.0.0-beta.1.tgz",
-      "integrity": "sha512-YkwNLKsMrNzyA4u1I8OvTxhYAfkAayP+rDGxcIuTOmv4IVZGoRCWMtYqUl40xdIVE0QmJpbkAuQtG7Vn3xOlHw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-gEzuyryoa24mv/cloFXFplRyj3MIAHPbU6y53EUQtbeK7Ou+8Gez4sKYW1VbflVBqhu4Mj+7KYG6fKEXxXlWKg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3",
         "posthtml-parser": "^0.4.1",
@@ -2166,45 +2379,55 @@
         }
       }
     },
-    "@parcel/transformer-inline-string": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-beta.1.tgz",
-      "integrity": "sha512-XfhPAXWvrWQSOwHGQU3koP6vs85mcjyKllVGcC24/Io2nZhzACw6br0fzZL2gSVZeEt+/TtfxVu7uA44S8tA8g==",
+    "@parcel/transformer-image": {
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-w2VS8gzoSyYYGXsDWmmi6mdPo63LUCif6/GZCWYFMoMiX/f0gWDZwo+OQUBixxdsTXbB7pdIp3Zat6W6CgZ/bw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
+      }
+    },
+    "@parcel/transformer-inline-string": {
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-c69EPTJrcqRyGwOakhTlmit8nDlwQSiwyhlmnLbZbBW0ZUtIZc1aP9/CtPTCIIP0J86Q0r1A3lo/SJ+uFY6GAw==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.0.0-beta.1.tgz",
-      "integrity": "sha512-60rrUF+ApahxKc1eQizyo7umvOhIRe3sxRIYub61qRPan2S7aU7PbScZ4bboh3alQYLztTNQh2VazM85oyiQSw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-uP3uSOGFmDVqQOGeg9VT36UKmAlbsR2FC9swN9mtg8cX3D1GN3lkHt0Vp6pEQG9XtAI1W6bg244XOvX+/LS4YQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0",
+        "@babel/core": "^7.12.0",
         "@babel/generator": "^7.0.0",
         "@babel/parser": "^7.0.0",
         "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/template": "^7.0.0",
+        "@babel/template": "^7.4.0",
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
-        "@parcel/babel-ast-utils": "2.0.0-beta.1",
-        "@parcel/babylon-walk": "2.0.0-beta.1",
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/scope-hoisting": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/babylon-walk": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/scope-hoisting": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "micromatch": "^4.0.2",
         "nullthrows": "^1.1.1",
         "semver": "^5.4.1"
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.0.0-beta.1.tgz",
-      "integrity": "sha512-v39TaEWgJnoOqOQGtZgZBAq3dihufqeSm9+szIxzm4FiwzOzzlyo9QiLSlCfjDbuWHFvQkU5AJKSlhdS2qbN3Q==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-SG9JzbqXVrbwdvAyDBgkfKDn/rYFEBJPRa30E6Q4qXEcZ1KklLlThVz8KEzvkmCfqglws2WM7nWduaG9pz8JIw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
         "json5": "^2.1.0"
       },
       "dependencies": {
@@ -2220,13 +2443,13 @@
       }
     },
     "@parcel/transformer-jsonld": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-jsonld/-/transformer-jsonld-2.0.0-beta.1.tgz",
-      "integrity": "sha512-rf1n90XjrYDCD4jZ3+z+acQm4hznOe2l2Os3aVLCs1jvf6TAXMOtkHN1ABh63GAON5LJsary3YdFNrullDRTFw==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-jsonld/-/transformer-jsonld-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-8Ico9TueuvbFzugB0sdwa6Q/Z+UlvY5Jdndvn21x4xPW3F9X00Zz1SI1tltPV8tlJjVJbX/C804lKQ1vp0dM9w==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/types": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/types": "2.0.0-nightly.483+a4cf3e95",
         "json5": "^2.1.2"
       },
       "dependencies": {
@@ -2242,54 +2465,45 @@
       }
     },
     "@parcel/transformer-less": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-less/-/transformer-less-2.0.0-beta.1.tgz",
-      "integrity": "sha512-jKi29fKEJW4R1e0Rwo2nTfEeIA11vdMs3tHOhkq1O3lfkmK9UF98uFlweLyfF8Mm7XznEqKL7aP58drJ8UqVuQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-less/-/transformer-less-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-4JspsKlMKKvVOgTPE2CwCFC4ih1HGsVRjzhJ6LOtThPEKYe/qYvhTG8qyNvreZHjjJBWb/GjDedQDEhm2bRGEQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19"
       }
     },
     "@parcel/transformer-mdx": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-mdx/-/transformer-mdx-2.0.0-beta.1.tgz",
-      "integrity": "sha512-M4Jjws7n5at/AVMiITz6KIMZMzlF7WHuhfQ+YzAqXS2Z+f0mJ/c2/XNOSVrKbcjn+9aKoSYqwq6vmJ6wUSaBXQ==",
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-mdx/-/transformer-mdx-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-yw9Xi3lw04pvjJJL7iAZosj3XF6oQ/TIzYlo1N199/JiNNvlHHRJBegRz1/sz/hbCEWfcJNRid6n2F5cHZ7YVw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-beta.1.tgz",
-      "integrity": "sha512-RLJcK5rsNv7wzehZfqR9w4lBXF+OKeza57HJ7KGph6bBtwTsLedlioQakU7uXFWprbZE6NUa2ZDIxUhWmP9kQA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-q+EXobC1zT15n55MRf7w2BfQY6GRbCicsssuvpjthdp0z62rNzFCn7GHW7UWn6dT9sSpu5mrw7NSLb9/Sw0T7A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "css-modules-loader-core": "^1.1.0",
         "nullthrows": "^1.1.1",
-        "postcss": "^7.0.5",
-        "postcss-value-parser": "^3.3.1",
+        "postcss-value-parser": "^4.1.0",
         "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        }
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-beta.1.tgz",
-      "integrity": "sha512-dUbB3dB57qtjqmf00VeZIQRNnbEVOLCGchTIQXOoa1Ys0YqcEHNOAP7yU/njykQtxIBNp41CRXkvLl+4M6egyQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-oEaVR39CzYmvxrG6IgTOjfAKge7sh34B1vn+gjQjeCnm32Frdx7nXse5k2QdWTrKEN+ICbgf+2fXdhsYnssH9w==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.11.3",
         "posthtml-parser": "^0.4.1",
@@ -2309,154 +2523,179 @@
       }
     },
     "@parcel/transformer-pug": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-pug/-/transformer-pug-2.0.0-beta.1.tgz",
-      "integrity": "sha512-o6jXARg1HuEetLdKRn6EuJ5YGFbql3mAtK+D/Tj5/DDg1RIlBK4Cih3Gi/lyCjHF7a7Woc0mKP09cA95va5ZUA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-pug/-/transformer-pug-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-g4Pkp3b3gyzZrkO+YywNHQCi9+oOzgvY0ohk0Ui0wGyj3DMoGNgGEZnkFhXPVcVRMWzlRGFopEjuv6Y8Maa0TQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.0.0-beta.1.tgz",
-      "integrity": "sha512-SLqd5KBH7k8Gh25MMUTdR6tdWWWTVKuQNF76uOzysIpdbQX/ix7v12wmyeSOxivrc1eDUtILkLUH0e9HIxWVvw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-lTTy+lT9KOCp4bTI+E3+qoKg2XtQmujg0wNUzaoqtvZNSROUY37py2bMX4H46GMHrRH6GlBpixB4lgIKa9rrQQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-react-refresh-babel": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-babel/-/transformer-react-refresh-babel-2.0.0-beta.1.tgz",
-      "integrity": "sha512-DlsjjujHGgmSEsazN9Ng/0Q7dMSATB7kxAe7CADE+Y8cf8kBmSeeuFokbnxTGg3TBeGMjeeHcOhXwXwNeHkEQQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-babel/-/transformer-react-refresh-babel-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-fUrr1sCuVwx0R4mI7H/W9KkE+LkDTjeN+PDqulaYQMwSubsyaKW38aDRKr53vsUOFUdxvrgtekw9LNRRuFolFw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "react-refresh": "^0.6.0"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-beta.1.tgz",
-      "integrity": "sha512-PJiCdXGQgd3Z2zVs1KLie9sU5kagtMMWNVHomJ9QeG4tnvoG/J4P4klJRLO218GqBnB/s4u8vNH0QbGuQO98HQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-zJVySYPaaY/WmJx/kW60Un2gY6Q8Co4r0/HyeFBYxxa4HXLv0lzp3519dL92+pam5KfY7smNBJoZ3WH4Ab6btw==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.0.0",
         "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
+        "@babel/template": "^7.4.0",
         "@babel/types": "^7.0.0",
-        "@parcel/babel-ast-utils": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
-        "react-refresh": "^0.6.0",
+        "@parcel/babel-ast-utils": "2.0.0-nightly.2105+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "react-refresh": "^0.9.0",
         "semver": "^5.4.1"
       }
     },
     "@parcel/transformer-sass": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.0.0-beta.1.tgz",
-      "integrity": "sha512-E5sPsmtmvqsB90YEbDD7VFQ5o6+t97YQD35aIZnsZHkuI9MhFEaVHROtzeq3n3nuZ6tjyr6rv2SseZj1yculzg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-71BZwFf5R9qDnPOmrPTNLe972Qz9bO5FZ5WkElxo50xXA/RGVv+Ymln4pUMaRQDiJtl41+RmpRDWhQF2v/pfaQ==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.0.0-beta.1",
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/fs": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-stylus": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-stylus/-/transformer-stylus-2.0.0-beta.1.tgz",
-      "integrity": "sha512-mTh4f59XVxM7vHRP183Cp+0bVOZ0/eyOWQrFBKBt27ZbJvLy2ynxFed/goYpjz8QT+ZJsjmPYViKLxrSdHaQTQ==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-stylus/-/transformer-stylus-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-vabzGOEI68WDZnU6bTfX8ivYyhYOeCEbJTvcfyTQ/v860/2YwdOqDv54RhTfKNnEwkoBnEDayclF2gZHphaMgg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-sugarss": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-sugarss/-/transformer-sugarss-2.0.0-beta.1.tgz",
-      "integrity": "sha512-73B7XDAZg0qymhlOEYhI4o8vdUbrm0ZUl/mqzXn13WsgstTtkwJPS8bX/QbyEnFq4xg/ktyezhmhNYLd+GAzjA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sugarss/-/transformer-sugarss-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-4RAWef808m2p1aWxbpABjBFivZXmw5EwiFLsh5QIF1YShgRdLwIwqkNjG+E11rUh9tGjpufntRsd9Wghvtg6Bw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "postcss": "^7.0.5"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "postcss": "^8.0.5"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.1.tgz",
+          "integrity": "sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==",
+          "dev": true,
+          "requires": {
+            "colorette": "^1.2.1",
+            "nanoid": "^3.1.20",
+            "source-map": "^0.6.1"
+          }
+        }
       }
     },
     "@parcel/transformer-toml": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-toml/-/transformer-toml-2.0.0-beta.1.tgz",
-      "integrity": "sha512-EHVS83evOcLJB2wvxQkZCWNjOAYaKg9qfnkbtvEztzx228KcQWg4IPiJgB6+dcBC5fuMBYIw0xZ24y3/3ZkPfg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-toml/-/transformer-toml-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-oBZF+b8uQ/EoGIAnLZx9fAxUHOzPOxbjmVUZFkxaxyjRADESJ6YC3TvjuHLE9mss0/ZqGvHc0boq3g52n0Z+Zg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/transformer-typescript-types": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.0.0-beta.1.tgz",
-      "integrity": "sha512-QVCe66C14zAsss71wso32OHo74aquVDyYfqO0a/+E62bTA2O8tLaeJ9dwMHgVRgw0tBobh/j6AKaOTeQFLqobA==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-wVn6h5N4s7gVrnQsxxkayRd46Rcb3Z5qDitHnnfy4GXAgFn644P+/L3tOa+xRkOjsj+Lu1/l1MS6l7zx8bHFUg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
-        "@parcel/ts-utils": "2.0.0-beta.1",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/ts-utils": "2.0.0-nightly.483+a4cf3e95",
         "nullthrows": "^1.1.1"
       }
     },
-    "@parcel/transformer-yaml": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-yaml/-/transformer-yaml-2.0.0-beta.1.tgz",
-      "integrity": "sha512-/pe59NOi6rtbE+YQEnOdxgNf5zMd5SXHnawICGa1Gn9rXDFswiKzD16O2meCy0VGF6dPsQdzL+k0PJlQd9/TDA==",
+    "@parcel/transformer-vue": {
+      "version": "2.0.0-nightly.2105",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-vue/-/transformer-vue-2.0.0-nightly.2105.tgz",
+      "integrity": "sha512-mokI2jQO2lu4UQwr+j6BV+vJpCuo1G+zg8FOZ4HY3jYZ4OUQRARkYdWIHWWzULvQkqNww1ZAE6g1DZIts2VpiQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.0.0-beta.1"
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.4.1"
+      }
+    },
+    "@parcel/transformer-yaml": {
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-yaml/-/transformer-yaml-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-AVWY4QPBtxxyHa2NL2lIPoLcr902ITNUo+Q+1a8e8JIJOjzCVcvyJKGNti/tWGEVZ8S6ncn5OO+wQioMJpEOpQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.0.0-nightly.483+a4cf3e95"
       }
     },
     "@parcel/ts-utils": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.0.0-beta.1.tgz",
-      "integrity": "sha512-lSw4fWL/PLsJruTmScQRVvtw2g75jsd55W08GuMdkr9iGIOXxTRZ4m4rdDBVsiS6Cgq2/l2M3zPnTiPX2do2kw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-ldi662b2Qs7e4SuKYr7W6VMGNfZS3AXZMh36TtriM8BJxtYQI0z624PVow4nmPLvrpKaeFRjzPRMMcru75mIpQ==",
       "dev": true,
       "requires": {
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/types": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-beta.1.tgz",
-      "integrity": "sha512-2aB5MoEyNUXb34IG1YVRiC5HTHgqWAX8/mM+JGAUit/kTb7eRVtnQtOhQHWyGyLqkEwbLrLo3s272sp5LNK90A==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-+rZyzEA5t248V1Ikx1ZWFqcsTvumlRGtTFmzeX790QX7hCpXoyYnYMs0M10B88zLLvYhFAo+ic6NkXYA3hl8cw==",
       "dev": true
     },
     "@parcel/utils": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-beta.1.tgz",
-      "integrity": "sha512-o+qTRMqe6QjdseYKZBGTOjnxRt4bIOEfH5ey9Ohl5fRGIfuWH7Tsq3fUkf/McvoAQyR6eo1vp7OrPBUQeQ6wxw==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-s0zMayXNi/0Je6HZVZbq62wpwexmBcD41ICQUDaMoDVCXFZ0YmDct/KN1rs+OiuWOlFvkRD/B/N3C4WH+kfz9A==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.0",
-        "@parcel/codeframe": "2.0.0-beta.1",
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/logger": "2.0.0-beta.1",
-        "@parcel/markdown-ansi": "2.0.0-beta.1",
-        "@parcel/source-map": "2.0.0-alpha.4.13",
+        "@parcel/codeframe": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/logger": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/markdown-ansi": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/source-map": "2.0.0-alpha.4.19",
         "ansi-html": "^0.0.7",
         "chalk": "^2.4.2",
         "clone": "^2.1.1",
         "fast-glob": "3.1.1",
+        "fastest-levenshtein": "^1.0.8",
         "is-glob": "^4.0.0",
         "is-url": "^1.2.2",
-        "js-levenshtein": "^1.1.6",
         "json5": "^1.0.1",
         "micromatch": "^4.0.2",
-        "node-forge": "^0.8.1",
+        "node-forge": "^0.10.0",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
-        "resolve": "^1.12.0",
-        "serialize-to-js": "^3.0.1",
-        "terser": "^3.7.3"
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2525,32 +2764,25 @@
       }
     },
     "@parcel/watcher": {
-      "version": "2.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.0-alpha.9.tgz",
-      "integrity": "sha512-k3luHa2W4W42uAe85v61HFMJKBf8txJmEJBB4BlHuNoFomA7lLX35nsg1APFYS/HKvf0oIEqEL1HvPRx+Dt+QA==",
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.0-alpha.8.tgz",
+      "integrity": "sha512-9aQu1SFkR6t1UYo3Mj1Vg39/Scaa9i4xGZnZ5Ug/qLyVzHmdjyKDyAbsbUDAd1O2e+MUhr5GI1w1FzBI6J31Jw==",
       "dev": true,
       "requires": {
-        "node-addon-api": "^3.0.2",
-        "node-gyp-build": "^4.2.3"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
-          "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==",
-          "dev": true
-        }
+        "lint-staged": "^10.0.8",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1"
       }
     },
     "@parcel/workers": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-beta.1.tgz",
-      "integrity": "sha512-8ycDNpBM9WoRVsHB+QXA/Y4I3z18vOQVFY+/vIcLNDIr61zKETwPjOmr5+6wSa6cMWaZBXYUjm2heJ6bPi1QXg==",
+      "version": "2.0.0-nightly.483",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-nightly.483.tgz",
+      "integrity": "sha512-TNAF3JxxAz/98oPrBzHupEGqs75swXNnw5D8yGXFiB5FlIsVqXsox7+XbK7Qrj12x4bHhOMY5gGnJ4VobbeYBg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/logger": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/logger": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
@@ -2559,6 +2791,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/http-proxy": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
+      "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
+      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/q": {
@@ -2601,6 +2854,16 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2618,6 +2881,21 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      }
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -3066,6 +3344,15 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3259,6 +3546,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -3502,6 +3795,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3516,6 +3815,29 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
       "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
       "dev": true
+    },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
+      }
     },
     "clone": {
       "version": "2.1.2",
@@ -3776,6 +4098,12 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -3800,9 +4128,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.0.tgz",
-      "integrity": "sha512-W2VYNB0nwQQE7tKS7HzXd7r2y/y2SVJl4ga6oH/dnaLFzM0o2lB2P3zCkWj5Wc/zyMYjtgd5Hmhk0ObkQFZOIA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+      "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
       "dev": true
     },
     "core-js-compat": {
@@ -4240,6 +4568,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -4610,6 +4944,24 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -4747,6 +5099,66 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "expand-brackets": {
@@ -4955,6 +5367,29 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+      "dev": true
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -4977,6 +5412,15 @@
       "dev": true,
       "requires": {
         "format": "^0.2.0"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-uri-to-path": {
@@ -5033,9 +5477,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
       "dev": true
     },
     "for-in": {
@@ -5128,6 +5572,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
+    },
     "get-port": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
@@ -5139,6 +5589,15 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
       "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -5494,119 +5953,23 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz",
-      "integrity": "sha512-aYk1rTKqLTus23X3L96LGNCGNgWpG4cG0XoZIT1GUPhhulEHX/QalnO6Vbo+WmKWi4AL2IidjuC0wZtbpg0yhQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+      "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
       "dev": true,
       "requires": {
+        "@types/http-proxy": "^1.17.4",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.20",
+        "micromatch": "^4.0.2"
       },
       "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -5625,6 +5988,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -5672,6 +6041,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "indexes-of": {
@@ -5722,10 +6097,13 @@
       }
     },
     "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5927,10 +6305,22 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true
     },
     "is-svg": {
@@ -5952,36 +6342,16 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
-      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
+      "integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
       "dev": true,
       "requires": {
-        "available-typed-arrays": "^1.0.0",
-        "es-abstract": "^1.17.4",
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
         "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "is-typedarray": {
@@ -6038,12 +6408,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true
     },
     "js-tokens": {
@@ -6112,6 +6476,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -6200,6 +6570,100 @@
         "type-check": "~0.3.2"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "lint-staged": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.3.tgz",
+      "integrity": "sha512-TanwFfuqUBLufxCc3RUtFEkFraSPNR3WzWcGF39R3f2J7S9+iF9W0KTVLfSy09lYGmZS5NDCxjNvhGMSJyFCWg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "commander": "^6.2.0",
+        "cosmiconfig": "^7.0.0",
+        "debug": "^4.2.0",
+        "dedent": "^0.7.0",
+        "enquirer": "^2.3.6",
+        "execa": "^4.1.0",
+        "listr2": "^3.2.2",
+        "log-symbols": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "string-argv": "0.3.1",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+          "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "listr2": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.2.3.tgz",
+      "integrity": "sha512-vUb80S2dSUi8YxXahO8/I/s29GqnOL8ozgHVLjfWQXa03BNEeS1TpBLjh2ruaqq5ufx46BRGvfymdBSuoXET5w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "figures": "^3.2.0",
+        "indent-string": "^4.0.0",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rxjs": "^6.6.3",
+        "through": "^2.3.8"
+      }
+    },
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
@@ -6238,13 +6702,16 @@
         "chalk": "^4.0.0"
       }
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "lowlight": {
@@ -6314,6 +6781,12 @@
         }
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6347,9 +6820,9 @@
       }
     },
     "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
       "dev": true
     },
     "mime-db": {
@@ -6447,6 +6920,12 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6479,15 +6958,15 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
+      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==",
       "dev": true
     },
     "node-forge": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-gyp-build": {
@@ -6660,6 +7139,23 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        }
+      }
     },
     "nth-check": {
       "version": "1.0.2",
@@ -6961,28 +7457,37 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parcel": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.0.0-beta.1.tgz",
-      "integrity": "sha512-Z2tzZoDws7q+99ihjpd3WX09BTao2miTk+S9URJXRJkVxxgoZSQJ+uwtxcosoDWwS6zv4RAXxtEMmiyMeaCuMQ==",
+      "version": "2.0.0-nightly.481",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.0.0-nightly.481.tgz",
+      "integrity": "sha512-0IpUOeqDrFwSA0AYElhTcHRXQ6iz3yYG4VYEt8lfMIbqAwouy/xS+bOMzT/myZVmnJEc0SEZ2CtIGfPZIBhyeQ==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.0.0-beta.1",
-        "@parcel/core": "2.0.0-beta.1",
-        "@parcel/diagnostic": "2.0.0-beta.1",
-        "@parcel/fs": "2.0.0-beta.1",
-        "@parcel/logger": "2.0.0-beta.1",
-        "@parcel/package-manager": "2.0.0-beta.1",
-        "@parcel/utils": "2.0.0-beta.1",
+        "@parcel/config-default": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/core": "2.0.0-nightly.481+a4cf3e95",
+        "@parcel/diagnostic": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/events": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/fs": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/logger": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/package-manager": "2.0.0-nightly.483+a4cf3e95",
+        "@parcel/utils": "2.0.0-nightly.483+a4cf3e95",
         "chalk": "^2.1.0",
         "commander": "^2.19.0",
         "get-port": "^4.2.0",
-        "react": "^16.7.0",
         "v8-compile-cache": "^2.0.0"
       },
       "dependencies": {
@@ -7489,6 +7994,23 @@
         }
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        }
+      }
+    },
     "parse-asn1": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
@@ -7547,6 +8069,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -7557,6 +8085,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
       "dev": true
     },
     "path-type": {
@@ -7594,6 +8128,15 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
     },
     "pn": {
       "version": "1.1.0",
@@ -8505,17 +9048,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -8540,6 +9072,16 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -8690,27 +9232,10 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "react-refresh": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.6.0.tgz",
-      "integrity": "sha512-Wv48N+GFt6Azvtl/LMvzNW9hvEyJdRQ48oVKIBAN7hjtvXXfxfVJXbPl/11SM1C/NIquIFXzzWCo6ZNH0I8I4g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
       "dev": true
     },
     "readable-stream": {
@@ -9112,6 +9637,15 @@
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -9150,6 +9684,12 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "send": {
@@ -9209,6 +9749,45 @@
       "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.1.tgz",
       "integrity": "sha512-F+NGU0UHMBO4Q965tjw7rvieNVjlH6Lqi2emq/Lc9LUURYJbiCzmpi4Cy1OOjjVPtxu0c+NE85LU6968Wko5ZA==",
       "dev": true
+    },
+    "serve-handler": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
+      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+          "dev": true
+        }
+      }
     },
     "serve-static": {
       "version": "1.14.1",
@@ -9713,6 +10292,12 @@
         "xtend": "^4.0.2"
       }
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -9752,6 +10337,25 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+          "dev": true
+        }
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -9760,6 +10364,12 @@
       "requires": {
         "ansi-regex": "^5.0.0"
       }
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
     },
     "stylehacks": {
       "version": "4.0.3",
@@ -9902,6 +10512,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
@@ -10078,6 +10694,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -10351,9 +10973,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",
@@ -10460,38 +11082,18 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
-      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.2",
-        "es-abstract": "^1.17.5",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
         "foreach": "^2.0.5",
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.1",
         "is-typed-array": "^1.1.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "word-wrap": {
@@ -10499,6 +11101,17 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "leasot": "^11.1.0",
-    "parcel": "^2.0.0-beta.1",
+    "parcel": "^2.0.0-nightly.467",
     "parcel-bundler": "^1.12.4"
   }
 }


### PR DESCRIPTION
This PR updates 46 (out of 47) high severity vunerabilities in outdated versions of dependencies.  This was done by running:

```
$ npm audit fix
```

I also deleted both node_modules and `package-lock.json` and then ran `npm install` again.
